### PR TITLE
Use keyof/lookup types to type Lens.key

### DIFF
--- a/examples/all/src/add-input/index.tsx
+++ b/examples/all/src/add-input/index.tsx
@@ -21,11 +21,11 @@ function addItem({ values, entry }: AppState): AppState {
 }
 
 const App = (props: { state: Atom<AppState> }) => {
-  const values = props.state.lens(x => x.values)
+  const values = props.state.lens('values')
   return (
     <div>
       <div>
-        <F.input { ...bind({ value: props.state.lens(x => x.entry) }) } type='text' />
+        <F.input { ...bind({ value: props.state.lens('entry') }) } type='text' />
         <input type='submit' value='Add' onClick={() => props.state.modify(addItem)} />
       </div>
       <F.ul>

--- a/examples/all/src/animated-counter/index.tsx
+++ b/examples/all/src/animated-counter/index.tsx
@@ -5,8 +5,8 @@ import * as Model from './model'
 const Counter = ({
   counterState = Atom.create(Model.defaultCounterState)
 }) => {
-  const count = counterState.view(x => x.count)
-  const absoluteCount = counterState.view(x => x.absoluteCount)
+  const count = counterState.view('count')
+  const absoluteCount = counterState.view('absoluteCount')
 
   return (
     <div>
@@ -26,8 +26,8 @@ const Counter = ({
 const AnimatedDiv = ({
   counterState = Atom.create(Model.defaultCounterState)
 }) => {
-  const displayState = counterState.lens(x => x.display)
-  const count = counterState.view(x => x.count)
+  const displayState = counterState.lens('display')
+  const count = counterState.view('count')
 
   const animDiv = displayState.map(displayState => {
     if (displayState) {
@@ -62,7 +62,7 @@ const AnimatedDiv = ({
 const App = ({
   state = Atom.create(Model.defaultAppState)
 }) => {
-  const counterState = state.lens(x => x.counter)
+  const counterState = state.lens('counter')
 
   return (
     <div>

--- a/examples/all/src/animated-counter/model.ts
+++ b/examples/all/src/animated-counter/model.ts
@@ -35,10 +35,10 @@ export function shouldHideCounter(count: number) {
 export function hideAfterFadeOut(counter: Atom<CounterState>) {
   // check if we still should hide
   if (shouldHideCounter(counter.get().count))
-    counter.lens(x => x.display).set(false)
+    counter.lens('display').set(false)
 }
 
 export function resetCounter(counter: Atom<CounterState>) {
-  counter.lens(x => x.count).set(0)
-  counter.lens(x => x.display).set(true)
+  counter.lens('count').set(0)
+  counter.lens('display').set(true)
 }

--- a/examples/all/src/big-table/index.tsx
+++ b/examples/all/src/big-table/index.tsx
@@ -85,7 +85,7 @@ const App = ({
         borderBottom: '1px solid black'
       }}
     >
-      <THead columns={state.view(x => x.columns)}/>
+      <THead columns={state.view('columns')}/>
     </table>
     <F.div
       {...bindElementProps({ ref: 'onScroll', scrollTop })}

--- a/examples/all/src/bmi/index.tsx
+++ b/examples/all/src/bmi/index.tsx
@@ -19,8 +19,8 @@ function getBmi(weight: number, height: number) {
 }
 
 const App = (props: { state: Atom<AppState> }) => {
-  const weight = props.state.lens(x => x.weightKg)
-  const height = props.state.lens(x => x.heightCm)
+  const weight = props.state.lens('weightKg')
+  const height = props.state.lens('heightCm')
 
   return (
     <div>

--- a/examples/all/src/change-color/index.tsx
+++ b/examples/all/src/change-color/index.tsx
@@ -29,8 +29,8 @@ namespace AppState {
 const isEqualTo = (expected: string) => (actual: string) => actual === expected
 
 const App = (props: { state: Atom<AppState> }) => {
-  const color = props.state.lens(x => x.style.color)
-  const font = props.state.lens(x => x.style.font)
+  const color = props.state.lens('style', 'color')
+  const font = props.state.lens('style', 'font')
   return (
     <div>
       <div>

--- a/examples/all/src/checkbox-undo-redo/index.tsx
+++ b/examples/all/src/checkbox-undo-redo/index.tsx
@@ -15,7 +15,7 @@ namespace AppState {
 
 const App = (props: { state: Atom<AppState> }) => {
   const history = History.create(props.state)
-  const checkboxes = history.state.lens(x => x.checkboxes)
+  const checkboxes = history.state.lens('checkboxes')
 
   return (
     <div>

--- a/examples/all/src/checkbox/index.tsx
+++ b/examples/all/src/checkbox/index.tsx
@@ -15,7 +15,7 @@ export const App = (props: { state: Atom<AppState> }) =>
   <div>
     <label>
       <F.input
-        {...bind({ checked: Atom.log(props.state.lens(x => x.checked), 'Checkbox') })}
+        {...bind({ checked: Atom.log(props.state.lens('checked'), 'Checkbox') })}
         type='checkbox'
       />
       Toggle me

--- a/examples/all/src/color-box/index.tsx
+++ b/examples/all/src/color-box/index.tsx
@@ -21,8 +21,8 @@ const Box = lift(styled.div`
 `)
 
 const App = (props: { state: Atom<AppState> }) => {
-  const color = props.state.lens(x => x.color)
-  const width = props.state.lens(x => x.width)
+  const color = props.state.lens('color')
+  const width = props.state.lens('width')
   return (
     <Box color={color} width={width}>
       Color: <F.input {...bind({ value: color })} type='text' />

--- a/examples/all/src/convert/index.tsx
+++ b/examples/all/src/convert/index.tsx
@@ -12,7 +12,7 @@ namespace AppState {
 }
 
 const App = (props: { state: Atom<AppState> }) => {
-  const temperature = props.state.lens(x => x.temperature)
+  const temperature = props.state.lens('temperature')
   return (
     <div>
       <F.input {...bind({ value: temperature })} type='text' />

--- a/examples/all/src/counter/index.tsx
+++ b/examples/all/src/counter/index.tsx
@@ -27,7 +27,7 @@ const Counter = (props: { count: Atom<number> }) =>
 const App = (props: { state: Atom<AppState> }) =>
   <div>
     Hello, world!
-    <Counter count={props.state.lens(x => x.counter.count)} />
+    <Counter count={props.state.lens('counter', 'count')} />
   </div>
 
 export default {

--- a/examples/all/src/hello/index.tsx
+++ b/examples/all/src/hello/index.tsx
@@ -14,8 +14,8 @@ namespace AppState {
 }
 
 const App = (props: { state: Atom<AppState> }) => {
-  const firstName = props.state.lens(x => x.firstName)
-  const lastName = props.state.lens(x => x.lastName)
+  const firstName = props.state.lens('firstName')
+  const lastName = props.state.lens('lastName')
   return (
     <div>
       First Name: <F.input {...bind({ value: firstName })} type='text' />

--- a/examples/all/src/http-search-github/index.tsx
+++ b/examples/all/src/http-search-github/index.tsx
@@ -62,13 +62,13 @@ function runSearch(result: Atom<typeof AppState.defaultState.result>, query: str
 }
 
 export const App = (props: { state: Atom<AppState> }) => {
-  const result = props.state.lens(x => x.result)
+  const result = props.state.lens('result')
   const repos = result.view(x => x && x.kind === ResultKind.Success ? x.value : [])
 
   return (
     <div>
       <div>
-        <F.input {...bind({ value: props.state.lens(x => x.searchString) })} type='text' />
+        <F.input {...bind({ value: props.state.lens('searchString') })} type='text' />
         <input
           type='submit'
           value='Search'

--- a/examples/all/src/increment-number/index.tsx
+++ b/examples/all/src/increment-number/index.tsx
@@ -31,7 +31,7 @@ const App = (props: { state: Atom<AppState> }) =>
         Observable
           .combineLatest(
             Observable.interval(1000).startWith(0).mapTo(1),
-            props.state.view(x => x.isRunning)
+            props.state.view('isRunning')
           )
           .scan((acc, [val, shouldIncrement]) => shouldIncrement ? acc + val : acc, 0)
       }

--- a/examples/all/src/input/index.tsx
+++ b/examples/all/src/input/index.tsx
@@ -13,8 +13,8 @@ namespace AppState {
 
 const App = (props: { state: Atom<AppState> }) =>
   <div>
-    <F.input {...bind({ value: props.state.lens(x => x.entry) })} type='text' />
-    <F.p>{props.state.view(x => x.entry)}</F.p>
+    <F.input {...bind({ value: props.state.lens('entry') })} type='text' />
+    <F.p>{props.state.view('entry')}</F.p>
   </div>
 
 export default {

--- a/examples/all/src/list-search/index.tsx
+++ b/examples/all/src/list-search/index.tsx
@@ -29,15 +29,15 @@ class App extends  React.Component<{ state: Atom<AppState> }, {}> {
 
   componentDidMount() {
     const { state } = this.props
-    const timer = state.lens(x => x.timer)
+    const timer = state.lens('timer')
 
     this._subscription = Observable
       .interval(1000)
       .subscribe(_ => {
-        state.lens(x => x.timer).modify(x => x === 0 ? 5 : x - 1)
+        state.lens('timer').modify(x => x === 0 ? 5 : x - 1)
 
         if (timer.get() === 5)
-          state.lens(x => x.searchList).set(getRandomSearchList())
+          state.lens('searchList').set(getRandomSearchList())
       })
   }
 
@@ -47,15 +47,15 @@ class App extends  React.Component<{ state: Atom<AppState> }, {}> {
 
   render() {
     const { state } = this.props
-    const search = state.lens(x => x.searchString)
+    const search = state.lens('searchString')
 
     return (
       <div>
         <F.input {...bind({ value: search })} />
-        <F.div>Timer: {state.view(x => x.timer)}</F.div>
+        <F.div>Timer: {state.view('timer')}</F.div>
         <F.div>
           {
-            Atom.combine(search, state.lens(x => x.searchList), (searchValue, list) => (
+            Atom.combine(search, state.lens('searchList'), (searchValue, list) => (
               <div>
                 {
                   list

--- a/examples/all/src/scroll/index.tsx
+++ b/examples/all/src/scroll/index.tsx
@@ -65,8 +65,8 @@ const ScrollInput = (props: { value: Atom<number>, label: string }) =>
   </div>
 
 const App = (props: { state: Atom<AppState> }) => {
-  const scrollTop = props.state.lens(x => x.scrollTop)
-  const scrollLeft = props.state.lens(x => x.scrollLeft)
+  const scrollTop = props.state.lens('scrollTop')
+  const scrollLeft = props.state.lens('scrollLeft')
 
   return (
     <div>

--- a/examples/all/src/slider/index.tsx
+++ b/examples/all/src/slider/index.tsx
@@ -13,8 +13,8 @@ namespace AppState {
 
 const App = (props: { state: Atom<AppState> }) =>
   <div>
-    <F.input {...bind({ value: props.state.lens(x => x.range) })} type='range' />
-    <F.p>Value: {props.state.view(x => x.range)}</F.p>
+    <F.input {...bind({ value: props.state.lens('range') })} type='range' />
+    <F.p>Value: {props.state.view('range')}</F.p>
   </div>
 
 export default {

--- a/examples/all/src/styled-components/index.tsx
+++ b/examples/all/src/styled-components/index.tsx
@@ -30,10 +30,10 @@ const Text = lift(styled.p`
 const App = (props: { state: Atom<AppState> }) =>
   <div>
     <Input
-      {...bind({ value: Atom.log(props.state.lens(x => x.entry), 'Input') })}
+      {...bind({ value: Atom.log(props.state.lens('entry'), 'Input') })}
       type='text'
     />
-    <Text>{props.state.view(x => x.entry)}</Text>
+    <Text>{props.state.view('entry')}</Text>
   </div>
 
 export default {

--- a/examples/all/src/timer/index.tsx
+++ b/examples/all/src/timer/index.tsx
@@ -76,7 +76,7 @@ class App extends React.Component<{ state: Atom<AppState> }, {}> {
   private _subscription: Subscription
 
   componentDidMount() {
-    const status = this.props.state.view(x => x.status)
+    const status = this.props.state.view('status')
 
     this._subscription = Observable
       .combineLatest(
@@ -89,7 +89,7 @@ class App extends React.Component<{ state: Atom<AppState> }, {}> {
         status === Status.RESET ? defaultTimeState : updateTime(time, val),
         defaultTimeState
       )
-      .subscribe(x => this.props.state.lens(x => x.time).set(x))
+      .subscribe(x => this.props.state.lens('time').set(x))
   }
 
   componentWillUnmount() {
@@ -98,8 +98,8 @@ class App extends React.Component<{ state: Atom<AppState> }, {}> {
 
   render() {
     const { state } = this.props
-    const time = state.lens(x => x.time)
-    const status = state.lens(x => x.status)
+    const time = state.lens('time')
+    const status = state.lens('status')
     const isStarted = status.view(x => x === Status.STARTED)
 
     return (
@@ -148,7 +148,7 @@ class App extends React.Component<{ state: Atom<AppState> }, {}> {
             )
           }
         </F.p>
-        <Laps laps={state.view(x => x.laps)} />
+        <Laps laps={state.view('laps')} />
       </div>
     )
   }

--- a/examples/all/src/todos/index.tsx
+++ b/examples/all/src/todos/index.tsx
@@ -21,7 +21,7 @@ const Todo = (props: { id: string, todo: Atom<TodoState> }) => {
 }
 
 const TodoList = (props: { state: Atom<AppState> }) => {
-  const todos = props.state.lens(x => x.todos)
+  const todos = props.state.lens('todos')
   return (
     <F.ul>
       {
@@ -62,11 +62,11 @@ const Footer = (props: { filter: Atom<string> }) => (
 export const App = (props: { state: Atom<AppState> }) =>
   <div>
     <div>
-      <F.input {...bind({ value: props.state.lens(x => x.value) })} type='text' />
+      <F.input {...bind({ value: props.state.lens('value') })} type='text' />
       <input type='submit' value='Add Todo' onClick={() => props.state.modify(addTodo)} />
     </div>
     <TodoList state={props.state} />
-    <Footer filter={props.state.lens(x => x.filter)} />
+    <Footer filter={props.state.lens('filter')} />
   </div>
 
 export default {

--- a/examples/all/src/tree/index.tsx
+++ b/examples/all/src/tree/index.tsx
@@ -13,10 +13,10 @@ const Counter = (props: { value: Atom<number> }) =>
   </div>
 
 const Node = (props: { state: Atom<NodeState>, removeNode?: () => void }): JSX.Element => {
-  const children = props.state.lens(x => x.children)
+  const children = props.state.lens('children')
   return (
     <div>
-      <Counter value={props.state.lens(x => x.value)} />
+      <Counter value={props.state.lens('value')} />
       {
         props.removeNode &&
         <F.input
@@ -46,7 +46,7 @@ const Node = (props: { state: Atom<NodeState>, removeNode?: () => void }): JSX.E
       <F.input
         type='submit'
         value='Add child'
-        onClick={() => props.state.lens(x => x.children).modify(x => [...x, defaultNodeState])}
+        onClick={() => props.state.lens('children').modify(x => [...x, defaultNodeState])}
       />
     </div>
   )
@@ -54,7 +54,7 @@ const Node = (props: { state: Atom<NodeState>, removeNode?: () => void }): JSX.E
 
 const App = (props: { state: Atom<AppState> }) =>
   <div>
-    <Node state={props.state.lens(x => x.tree)} />
+    <Node state={props.state.lens('tree')} />
   </div>
 
 export default {

--- a/examples/all/src/update-number/index.tsx
+++ b/examples/all/src/update-number/index.tsx
@@ -37,10 +37,10 @@ function getUpdateNumberObservable(buffer: number[]) {
 }
 
 const App = (props: { state: Atom<AppState> }) => {
-  const value = props.state.view(x => x.value)
+  const value = props.state.view('value')
   return (
     <div>
-      <F.input type='number' {...bind({ value: props.state.lens(x => x.inputValue) })} />
+      <F.input type='number' {...bind({ value: props.state.lens('inputValue') })} />
       <input
         type='submit'
         value='Update'
@@ -65,8 +65,8 @@ const App = (props: { state: Atom<AppState> }) => {
               .switchMap(getUpdateNumberObservable)
               .merge(value.first())
           }
-        </F.span> 
-      </div>   
+        </F.span>
+      </div>
     </div>
   )
 }

--- a/examples/all/src/utils/history.ts
+++ b/examples/all/src/utils/history.ts
@@ -25,7 +25,7 @@ export interface History<T> {
 
 export namespace History {
   export function create<T>(historyState: Atom<HistoryState<T>>): History<T> {
-    const position = historyState.lens(x => x.position)
+    const position = historyState.lens('position')
     const redoCount = historyState.view(s => s.history.length - s.position - 1)
 
     return {

--- a/examples/todomvc/src/model.ts
+++ b/examples/todomvc/src/model.ts
@@ -22,10 +22,10 @@ export const defaultState: AppState = {
 
 export class AppModel {
   constructor(public state: Atom<AppState>) {
-    this.todos = this.state.lens(x => x.todos)
+    this.todos = this.state.lens('todos')
   }
 
-  public readonly todos = this.state.lens(x => x.todos)
+  public readonly todos = this.state.lens('todos')
 
   add(title: string) {
     this.state.modify(({ todos, nextId }) => ({

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grammarly/focal",
   "version": "0.0.0-dev",
-  "versionBase": "0.5",
+  "versionBase": "0.6",
   "description": "FRP UI with React, observables, immutable data and lenses",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/src/atom/base.ts
+++ b/src/atom/base.ts
@@ -8,7 +8,6 @@ import {
   Observable, Subscriber, Subscription, BehaviorSubject
 } from 'rxjs/Rx'
 
-// tslint:disable no-unused-vars
 /**
  * Read-only atom.
  *
@@ -90,9 +89,7 @@ export interface ReadOnlyAtom<T> extends Observable<T> {
   view<U>(lens: Lens<T, U>): ReadOnlyAtom<U>
   view<U>(prism: Prism<T, U>): ReadOnlyAtom<Option<U>>
 }
-// tslint:enable no-unused-vars
 
-// tslint:disable no-unused-vars
 /**
  * A read/write atom.
  *

--- a/src/atom/base.ts
+++ b/src/atom/base.ts
@@ -81,27 +81,46 @@ export interface ReadOnlyAtom<T> extends Observable<T> {
   view<U>(getter: (x: T) => U): ReadOnlyAtom<U>
 
   /**
-   * View this atom through a lens.
+   * View this atom through a given lens.
    *
    * @param lens lens that defines the view
    * @returns atom viewed through the given transformation
    */
   view<U>(lens: Lens<T, U>): ReadOnlyAtom<U>
+
+  /**
+   * View this atom through a given prism.
+   *
+   * @param prism prism that defines the view
+   * @returns atom viewed through the given transformation
+   */
   view<U>(prism: Prism<T, U>): ReadOnlyAtom<Option<U>>
 
+  /**
+   * View this atom at a property of given name.
+   */
   view<K extends keyof T>(k: K): ReadOnlyAtom<T[K]>
 
+  /**
+   * View this atom at a give property path.
+   */
   view<
     K1 extends keyof T,
     K2 extends keyof T[K1]
   >(k1: K1, k2: K2): ReadOnlyAtom<T[K1][K2]>
 
+  /**
+   * View this atom at a give property path.
+   */
   view<
     K1 extends keyof T,
     K2 extends keyof T[K1],
     K3 extends keyof T[K1][K2]
   >(k1: K1, k2: K2, k3: K3): ReadOnlyAtom<T[K1][K2][K3]>
 
+  /**
+   * View this atom at a give property path.
+   */
   view<
     K1 extends keyof T,
     K2 extends keyof T[K1],
@@ -109,6 +128,9 @@ export interface ReadOnlyAtom<T> extends Observable<T> {
     K4 extends keyof T[K1][K2][K3]
   >(k1: K1, k2: K2, k3: K3, k4: K4): ReadOnlyAtom<T[K1][K2][K3][K4]>
 
+  /**
+   * View this atom at a give property path.
+   */
   view<
     K1 extends keyof T,
     K2 extends keyof T[K1],
@@ -144,11 +166,15 @@ export interface Atom<T> extends ReadOnlyAtom<T> {
   set(newValue: T): void
 
   /**
-   * Lens into this atom. The argument is a property expression, which
-   * is a limited form of a getter, with following restrictions:
+   * Create a lensed atom using a property expression, which specifies
+   * a path inside the atom value's data structure.
+   *
+   * The property expression is a limited form of a getter,
+   * with following restrictions:
    * - should be a pure function
    * - should be a single-expression function (i.e. return immediately)
    * - should only access object properties (nested access is OK)
+   * - should not access array items
    *
    * @example
    * const atom = Atom.create({ a: { b: 5 } })
@@ -158,32 +184,44 @@ export interface Atom<T> extends ReadOnlyAtom<T> {
    * // => { a: { b: 6 } }
    * @template U destination value type
    * @param propExpr property expression
-   * @returns lensed atom
+   * @returns a lensed atom
    */
   lens<U>(propExpr: PropExpr<T, U>): Atom<U>
 
   /**
-   * Lens into this atom.
+   * Create a lensed atom by supplying a lens.
    *
    * @template U destination value type
    * @param lens a lens
-   * @returns lensed atom
+   * @returns a lensed atom
    */
   lens<U>(lens: Lens<T, U>): Atom<U>
 
+  /**
+   * Create a lensed atom that's focused on a property of given name.
+   */
   lens<K extends keyof T>(k: K): Atom<T[K]>
 
+  /**
+   * Create a lensed atom that's focused on a given property path.
+   */
   lens<
     K1 extends keyof T,
     K2 extends keyof T[K1]
   >(k1: K1, k2: K2): Atom<T[K1][K2]>
 
+  /**
+   * Create a lensed atom that's focused on a given property path.
+   */
   lens<
     K1 extends keyof T,
     K2 extends keyof T[K1],
     K3 extends keyof T[K1][K2]
   >(k1: K1, k2: K2, k3: K3): Atom<T[K1][K2][K3]>
 
+  /**
+   * Create a lensed atom that's focused on a given property path.
+   */
   lens<
     K1 extends keyof T,
     K2 extends keyof T[K1],
@@ -191,6 +229,9 @@ export interface Atom<T> extends ReadOnlyAtom<T> {
     K4 extends keyof T[K1][K2][K3]
   >(k1: K1, k2: K2, k3: K3, k4: K4): Atom<T[K1][K2][K3][K4]>
 
+  /**
+   * Create a lensed atom that's focused on a given property path.
+   */
   lens<
     K1 extends keyof T,
     K2 extends keyof T[K1],

--- a/src/atom/base.ts
+++ b/src/atom/base.ts
@@ -172,6 +172,32 @@ export interface Atom<T> extends ReadOnlyAtom<T> {
   lens<U>(lens: Lens<T, U>): Atom<U>
 
   lens<K extends keyof T>(k: K): Atom<T[K]>
+
+  lens<
+    K1 extends keyof T,
+    K2 extends keyof T[K1]
+  >(k1: K1, k2: K2): Atom<T[K1][K2]>
+
+  lens<
+    K1 extends keyof T,
+    K2 extends keyof T[K1],
+    K3 extends keyof T[K1][K2]
+  >(k1: K1, k2: K2, k3: K3): Atom<T[K1][K2][K3]>
+
+  lens<
+    K1 extends keyof T,
+    K2 extends keyof T[K1],
+    K3 extends keyof T[K1][K2],
+    K4 extends keyof T[K1][K2][K3]
+  >(k1: K1, k2: K2, k3: K3, k4: K4): Atom<T[K1][K2][K3][K4]>
+
+  lens<
+    K1 extends keyof T,
+    K2 extends keyof T[K1],
+    K3 extends keyof T[K1][K2],
+    K4 extends keyof T[K1][K2][K3],
+    K5 extends keyof T[K1][K2][K3][K4]
+  >(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5): Atom<T[K1][K2][K3][K4][K5]>
 }
 
 export abstract class AbstractReadOnlyAtom<T>
@@ -216,18 +242,18 @@ export abstract class AbstractAtom<T>
   lens<U>(lens: Lens<T, U>): Atom<U>
   lens<K extends keyof T>(k: K): Atom<T[K]>
 
-  lens<U>(arg: Lens<T, U> | PropExpr<T, U> | string): Atom<any> {
-    return typeof arg === 'function'
-      // handle lens(prop expr) case
-      // tslint:disable-next-line no-use-before-declare
-      ? new LensedAtom<T, U>(
-        this, Lens.prop(arg as (x: T) => U), structEq)
-      : typeof arg === 'string'
-        // tslint:disable-next-line no-use-before-declare
-        ? new LensedAtom(this, Lens.key(arg), structEq)
-        // handle lens(lens) case
-        // tslint:disable-next-line no-use-before-declare
-        : new LensedAtom<T, U>(this, arg as Lens<T, U>, structEq)
+  lens<U>(arg1: Lens<T, U> | PropExpr<T, U> | string, ...args: string[]): Atom<any> {
+    // tslint:disable no-use-before-declare
+
+    // lens(prop expr) case
+    return typeof arg1 === 'function'
+      ? new LensedAtom<T, U>(this, Lens.prop(arg1 as (x: T) => U), structEq)
+      // lens('key') case
+      : typeof arg1 === 'string'
+        ? new LensedAtom(this, Lens.compose(Lens.key(arg1), ...args.map(Lens.key)), structEq)
+        // lens(lens) case
+        : new LensedAtom<T, U>(this, arg1 as Lens<T, U>, structEq)
+    // tslint:enable no-use-before-declare
   }
 }
 

--- a/src/atom/base.ts
+++ b/src/atom/base.ts
@@ -90,6 +90,32 @@ export interface ReadOnlyAtom<T> extends Observable<T> {
   view<U>(prism: Prism<T, U>): ReadOnlyAtom<Option<U>>
 
   view<K extends keyof T>(k: K): ReadOnlyAtom<T[K]>
+
+  view<
+    K1 extends keyof T,
+    K2 extends keyof T[K1]
+  >(k1: K1, k2: K2): ReadOnlyAtom<T[K1][K2]>
+
+  view<
+    K1 extends keyof T,
+    K2 extends keyof T[K1],
+    K3 extends keyof T[K1][K2]
+  >(k1: K1, k2: K2, k3: K3): ReadOnlyAtom<T[K1][K2][K3]>
+
+  view<
+    K1 extends keyof T,
+    K2 extends keyof T[K1],
+    K3 extends keyof T[K1][K2],
+    K4 extends keyof T[K1][K2][K3]
+  >(k1: K1, k2: K2, k3: K3, k4: K4): ReadOnlyAtom<T[K1][K2][K3][K4]>
+
+  view<
+    K1 extends keyof T,
+    K2 extends keyof T[K1],
+    K3 extends keyof T[K1][K2],
+    K4 extends keyof T[K1][K2][K3],
+    K5 extends keyof T[K1][K2][K3][K4]
+  >(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5): ReadOnlyAtom<T[K1][K2][K3][K4][K5]>
 }
 
 /**
@@ -159,20 +185,19 @@ export abstract class AbstractReadOnlyAtom<T>
   view<U>(prism: Prism<T, U>): ReadOnlyAtom<Option<U>>
   view<K extends keyof T>(k: K): ReadOnlyAtom<T[K]>
 
-  view<U>(
-    arg?: ((x: T) => U) | Lens<T, U> | Prism<T, U> | string
-  ): ReadOnlyAtom<any> {
+  view<U>(...args: any[]): ReadOnlyAtom<any> {
     // tslint:disable no-use-before-declare
-    return arg !== undefined
-      ? typeof arg === 'function'
-        // handle view(getter) case
-        ? new AtomViewImpl<T, U>(this, arg as (x: T) => U)
-        : typeof arg === 'string'
-          ? new AtomViewImpl<T, U>(this, Lens.key(arg).get)
-          // handle view(lens) and view(prism) cases
+    return args[0] !== undefined
+      // view(getter) case
+      ? typeof args[0] === 'function'
+        ? new AtomViewImpl<T, U>(this, args[0] as (x: T) => U)
+        // view('key') case
+        : typeof args[0] === 'string'
+          ? new AtomViewImpl<T, U>(this, Lens.compose<T, U>(...args.map(Lens.key())).get)
+          // view(lens) and view(prism) cases
           // @NOTE single case handles both lens and prism arg
-          : new AtomViewImpl<T, U>(this, x => (arg as Lens<T, U>).get(x))
-      // handle view() case
+          : new AtomViewImpl<T, U>(this, x => (args[0] as Lens<T, U>).get(x))
+      // view() case
       : this as ReadOnlyAtom<T>
     // tslint:enable no-use-before-declare
   }

--- a/src/atom/base.ts
+++ b/src/atom/base.ts
@@ -187,20 +187,22 @@ export abstract class AbstractAtom<T>
     this.modify(() => x)
   }
 
-  // tslint:disable no-unused-vars
   lens<U>(propExpr: PropExpr<T, U>): Atom<U>
   lens<U>(lens: Lens<T, U>): Atom<U>
-  // tslint:enable no-unused-vars
+  lens<K extends keyof T>(k: K): Atom<T[K]>
 
-  lens<U>(arg: Lens<T, U> | PropExpr<T, U>): Atom<U> {
+  lens<U>(arg: Lens<T, U> | PropExpr<T, U> | string): Atom<any> {
     return typeof arg === 'function'
       // handle lens(prop expr) case
       // tslint:disable-next-line no-use-before-declare
       ? new LensedAtom<T, U>(
         this, Lens.prop(arg as (x: T) => U), structEq)
-      // handle lens(lens) case
-      // tslint:disable-next-line no-use-before-declare
-      : new LensedAtom<T, U>(this, arg as Lens<T, U>, structEq)
+      : typeof arg === 'string'
+        // tslint:disable-next-line no-use-before-declare
+        ? new LensedAtom(this, Lens.key(arg), structEq)
+        // handle lens(lens) case
+        // tslint:disable-next-line no-use-before-declare
+        : new LensedAtom<T, U>(this, arg as Lens<T, U>, structEq)
   }
 }
 

--- a/src/lens/base.ts
+++ b/src/lens/base.ts
@@ -113,7 +113,6 @@ export namespace Lens {
     }
   }
 
-  // tslint:disable no-unused-vars
   /**
    * Compose several lenses, where each subsequent lens' state type is the previous
    * lens' output type.
@@ -126,18 +125,22 @@ export namespace Lens {
    * @template A the resulting lens' output
    */
   export function compose<T, U>(l: Lens<T, U>): Lens<T, U>
+
   export function compose<T1, T2, U>(l1: Lens<T1, T2>, l2: Lens<T2, U>): Lens<T1, U>
+
   export function compose<T1, T2, T3, U>(
     l1: Lens<T1, T2>, l2: Lens<T2, T3>, l3: Lens<T3, U>
   ): Lens<T1, U>
+
   export function compose<T1, T2, T3, T4, U>(
     l1: Lens<T1, T2>, l2: Lens<T2, T3>, l3: Lens<T3, T4>, l4: Lens<T4, U>
   ): Lens<T1, U>
+
   export function compose<T1, T2, T3, T4, T5, U>(
     l1: Lens<T1, T2>, l2: Lens<T2, T3>, l3: Lens<T3, T4>, l4: Lens<T4, T5>, l5: Lens<T5, U>
   ): Lens<T1, U>
+
   export function compose<T, U>(...lenses: Lens<any, any>[]): Lens<T, U>
-  // tslint:enable no-unused-vars
 
   export function compose<T, U>(...lenses: Lens<any, any>[]): Lens<T, U> {
     if (lenses.length === 0) {

--- a/src/lens/json.ts
+++ b/src/lens/json.ts
@@ -73,7 +73,8 @@ export function extractPropertyPath<TObject, TProperty>(
 
 export function keyImpl(k: string): Prism<{ [k: string]: any }, any>
 export function keyImpl<TValue>(k: string): Prism<{ [k: string]: TValue }, TValue>
-export function keyImpl<TObject>(): <K extends keyof TObject>(k: K) => Lens<TObject, TObject[K]>
+export function keyImpl<TObject = any>():
+  <K extends keyof TObject>(k: K) => Lens<TObject, TObject[K]>
 
 export function keyImpl<TObject>(k?: string) {
   return k === undefined

--- a/src/lens/json.ts
+++ b/src/lens/json.ts
@@ -71,9 +71,70 @@ export function extractPropertyPath<TObject, TProperty>(
   return parsePropertyPath(target.toString())
 }
 
+// @NOTE only need this interface to add JSDocs for this call.
+export interface KeyImplFor<TObject> {
+  /**
+   * Create a lens focusing on a key of an object.
+   *
+   * Requires two subsequent calls, first with only a type argument and no function
+   * arguments and second with the key argument.
+   *
+   * This enables better auto-completion, and is required because TypeScript does not
+   * allow to specify only some of the type arguments.
+   *
+   * This is the second call, where you supply the key argument.
+   * @example
+   * interface SomeObject {
+   *   someProp: number
+   * }
+   *
+   * const lens = Lens.key<SomeObject>()('someProp')
+   */
+  <K extends keyof TObject>(k: K): Lens<TObject, TObject[K]>
+}
+
+/**
+ * Create a prism focusing on a key of a dictionary.
+ *
+ * @param k the key to focus on
+ */
 export function keyImpl<TValue = any>(k: string): Prism<{ [k: string]: TValue }, TValue>
-export function keyImpl<TObject = any>():
-  <K extends keyof TObject>(k: K) => Lens<TObject, TObject[K]>
+
+/**
+ * Create a lens focusing on a key of an object.
+ *
+ * Requires two subsequent calls, first with only a type argument and no function
+ * arguments and second with the key argument.
+ *
+ * This enables better auto-completion, and is required because TypeScript does not
+ * allow to specify only some of the type arguments.
+ *
+ * This is the first call, where you only supply the type argument.
+ *
+ * @example
+ * interface SomeObject {
+ *   someProp: number
+ * }
+ *
+ * const lens = Lens.key<SomeObject>()('someProp')
+ * @template TObject type of the data structure the lens is focusing into
+ */
+// @NOTE we're doing this in two subsequent function applications because TS can either
+// infer all type parameters or none, and in this case there's nothing for it to infer the
+// TObject parameter from.
+//
+// By doing this in two function applications we can make TS infer they key type parameter
+// (K), which enables auto-completion for keys without needing to also state the key twice,
+// once as a type argument, and once as a function argument.
+//
+// Without this hack, it would look like this:
+//   keyImpl<SomeObject, 'someKey'>('someKey')
+//
+// Instead, we get this:
+//   keyImpl<SomeObject>()('someKey')
+//
+// Pretty cool!
+export function keyImpl<TObject = any>(): KeyImplFor<TObject>
 
 export function keyImpl<TObject>(k?: string) {
   return k === undefined

--- a/src/lens/json.ts
+++ b/src/lens/json.ts
@@ -54,7 +54,7 @@ export function parsePropertyPath(getterSource: string): string[] {
 }
 
 /**
- * Extract a list of property names from a {@link LensExpr}
+ * Extract a list of property names from a {@link PropExpr}
  *
  * @param target The target property expressions
  * @example
@@ -152,14 +152,6 @@ export function findImpl<T>(predicate: (x: T) => boolean): Prism<T[], T> {
 // together with the lens type.
 declare module './base' {
   export namespace Lens {
-    /**
-     * Create a prism to an object's key.
-     *
-     * @static
-     * @template TValue the type of key's value
-     * @param k target key name
-     * @returns a lens to an object's value at key k
-     */
     export let key: typeof keyImpl
 
     /**

--- a/src/lens/json.ts
+++ b/src/lens/json.ts
@@ -83,10 +83,6 @@ export function keyImpl(k: string): Prism<{ [k: string]: any }, any> {
   )
 }
 
-export function unsafeKeyImpl<TValue>(k: string): Prism<{ [k: string]: any }, TValue> {
-  return Lens.key(k)
-}
-
 export function propImpl<TObject, TProperty>(
   getter: PropExpr<TObject, TProperty>
 ): Lens<TObject, TProperty> {
@@ -160,16 +156,6 @@ declare module './base' {
     export let key: typeof keyImpl
 
     /**
-     * Create an *unsafe* prism to an object's key.
-     *
-     * This optic is unsafe in it's generic parameter, as it disregards the
-     * actual type of the value at runtime – it just does unsafe type assertion.
-     *
-     * @TODO how's this different from key?
-     */
-    export let unsafeKey: typeof unsafeKeyImpl
-
-    /**
      * Create a lens to an object's property. The argument is a property expression, which
      * is a limited form of a getter, with following restrictions:
      * - should be a pure function
@@ -222,7 +208,6 @@ declare module './base' {
 }
 
 Lens.key = keyImpl
-Lens.unsafeKey = unsafeKeyImpl
 Lens.prop = propImpl
 Lens.index = indexImpl
 Lens.withDefault = withDefaultImpl

--- a/src/lens/json.ts
+++ b/src/lens/json.ts
@@ -71,8 +71,7 @@ export function extractPropertyPath<TObject, TProperty>(
   return parsePropertyPath(target.toString())
 }
 
-export function keyImpl(k: string): Prism<{ [k: string]: any }, any>
-export function keyImpl<TValue>(k: string): Prism<{ [k: string]: TValue }, TValue>
+export function keyImpl<TValue = any>(k: string): Prism<{ [k: string]: TValue }, TValue>
 export function keyImpl<TObject = any>():
   <K extends keyof TObject>(k: K) => Lens<TObject, TObject[K]>
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,8 +8,13 @@ export function setKey<T, K extends keyof T>(k: K, v: T[K], o: T): T {
   if (k in o && structEq(v, o[k])) {
     return o
   } else {
-    // @NOTE is this the fastest way to do it?
-    return Object.assign({}, o, { [k as string]: v })
+    // this is the fastest way to do it, see
+    // https://jsperf.com/focal-setkey-for-loop-vs-object-assign
+    const r: { [k in keyof T]: T[k] } = {} as any
+    for (const p in o) r[p] = o[p]
+    r[k] = v
+
+    return r
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,19 +4,12 @@ export { equals as structEq } from './equals'
 
 export const DEV_ENV = typeof process !== 'undefined' && process.env.NODE_ENV !== 'production'
 
-export function setKey<T>(k: string, v: T, o?: { [k: string]: any; }) {
-  if (o === undefined) {
-    return { [k]: v }
-  } else if (k in o && structEq(v, o[k])) {
+export function setKey<T, K extends keyof T>(k: K, v: T[K], o: T): T {
+  if (k in o && structEq(v, o[k])) {
     return o
   } else {
-    const r: { [k: string]: any; } = { [k]: v }
-    for (const p in o) {
-      if (p !== k) {
-        r[p] = o[p]
-      }
-    }
-    return r
+    // @NOTE is this the fastest way to do it?
+    return Object.assign({}, o, { [k as string]: v })
   }
 }
 

--- a/test/test_atom.ts
+++ b/test/test_atom.ts
@@ -108,6 +108,19 @@ test('atom', t => {
     t.end()
   })
 
+  t.test('readonly, safe key, simple', t => {
+    const source = Atom.create({ a: 5 })
+    const view = source.view('a')
+
+    t.isEqual(view.get(), 5)
+
+    source.modify(x => ({ a: x.a + 1 }))
+
+    t.isEqual(view.get(), 6)
+
+    t.end()
+  })
+
   t.test('view observable semantics', t => {
     const source = Atom.create(1)
     const view = source.view(x => x + 1)

--- a/test/test_atom.ts
+++ b/test/test_atom.ts
@@ -72,6 +72,14 @@ test('atom', t => {
     })
   })
 
+  t.test('lensed, nested safe key', t => {
+    testAtom(t, x => {
+      const source = Atom.create({ a: { b: { c: x } } })
+      const lensed = source.lens('a', 'b', 'c')
+      return lensed
+    })
+  })
+
   t.test('lensed, safe key, chained lenses', t => {
     testAtom(t, x => {
       const source = Atom.create({ a: { b: { c: x } } })

--- a/test/test_atom.ts
+++ b/test/test_atom.ts
@@ -72,6 +72,14 @@ test('atom', t => {
     })
   })
 
+  t.test('lensed, safe key, chained lenses', t => {
+    testAtom(t, x => {
+      const source = Atom.create({ a: { b: { c: x } } })
+      const lensed = source.lens('a').lens('b').lens('c')
+      return lensed
+    })
+  })
+
   t.test('lensed, chained + complex', t => {
     const source = Atom.create({ a: { b: { c: 5 } } })
     const lensed =
@@ -79,6 +87,25 @@ test('atom', t => {
         .lens(x => x.a)
         .lens(x => x.b)
         .lens(x => x.c)
+        .lens(
+          Lens.create(
+            (x: number) => x + 1,
+            (v: number, _: number) => v - 1))
+
+    t.isEqual(lensed.get(), 6)
+
+    lensed.set(6)
+
+    t.isEqual(lensed.get(), 6)
+
+    t.end()
+  })
+
+  t.test('lensed, safe key, chained + complex', t => {
+    const source = Atom.create({ a: { b: { c: 5 } } })
+    const lensed =
+      source
+        .lens('a').lens('b').lens('c')
         .lens(
           Lens.create(
             (x: number) => x + 1,

--- a/test/test_atom.ts
+++ b/test/test_atom.ts
@@ -148,6 +148,19 @@ test('atom', t => {
     t.end()
   })
 
+  t.test('readonly, safe key, complex', t => {
+    const source = Atom.create({ a: { b: { c: 5 } } })
+    const view = source.view('a', 'b', 'c')
+
+    t.isEqual(view.get(), 5)
+
+    source.modify(x => ({ a: { b: { c: x.a.b.c + 1 } } }))
+
+    t.isEqual(view.get(), 6)
+
+    t.end()
+  })
+
   t.test('view observable semantics', t => {
     const source = Atom.create(1)
     const view = source.view(x => x + 1)

--- a/test/test_lens.ts
+++ b/test/test_lens.ts
@@ -169,6 +169,22 @@ test('json', t => {
     t.end()
   })
 
+  t.test('type safe key', t => {
+    const s = { a: 5, b: '6' }
+
+    testLens<typeof s, (typeof s)['a']>(
+      t, 'type safe key 1',
+      Lens.key<typeof s>()('a'), s, 5, 6, 7
+    )
+
+    testLens<typeof s, (typeof s)['b']>(
+      t, 'type safe key 1',
+      Lens.key<typeof s>()('b'), s, '6', '7', 'hello'
+    )
+
+    t.end()
+  })
+
   t.end()
 })
 

--- a/test/test_lens.ts
+++ b/test/test_lens.ts
@@ -178,7 +178,7 @@ test('json', t => {
     )
 
     testLens<typeof s, (typeof s)['b']>(
-      t, 'type safe key 1',
+      t, 'type safe key 2',
       Lens.key<typeof s>()('b'), s, '6', '7', 'hello'
     )
 


### PR DESCRIPTION
The property expression approach to create lenses has been very useful, but has always been a hack. The fact that we parse the property expression function's source code with regular expressions at runtime doesn't inspire any confidence just from its description alone. We also had several problems integrating with different instrumentation tools.

This PR implements alternative approach to create lenses and views. It's just as type safe as the property expression way. It also allows you to use the auto-completion feature (only tested in VSCode though).

The rename refactoring unfortunately doesn't work with string keys. Maybe we can find a workaround, or maybe we can decide to live with it. I would like to deprecate the property expression thing at some point, but would only like to do that if it will not significantly worsen the development UX.

Changes in this PR:
- [x] Another `Lens.key` overload that looks like this:

    ```
    function key<TObject = any>():
      <K extends keyof TObject>(k: K) => Lens<TObject, TObject[K]>
    ```
- [x] `Atom.view` and `Atom.lens` overloads to do `keyof`-typed views/lenses:

    ```
    view<K extends keyof T>(k: K): ReadOnlyAtom<T[K]>
    lens<K extends keyof T>(k: K): Atom<T[K]>
    ```
    This also adds several variadic overloads (up to 5 nested keys) for both `.view` and `.lens`.
- [x] Changed examples to use this new feature instead of property expressions.
- [x] Removed `Lens.unsafeKey`. Not even sure what was the original idea behind it, it's not used anywhere ATM.
- [x] Some cleanup here and there.
- [x] Add JSDocs to new overloads.