### PR TITLE
Issue a warning for non-behavior observable props

### DIFF
--- a/src/react/react.ts
+++ b/src/react/react.ts
@@ -327,8 +327,9 @@ const handleError = (e: any) => {
 function warnEmptyObservable(componentName: string | undefined) {
   warning(
     `${componentName ? `The component <${componentName}>` : 'An unnamed component'} has ` +
-    `received an empty observable in one of its props. Since such observable never calls ` +
-    `its subscription handler, this component can never be rendered. ` +
+    `received an observable that doesn't immediately emit a value in one of its props. ` +
+    `Since this observable hasn't yet called its subscription handler, the component ` +
+    `can not be rendered at the time. ` +
     `Check the props of ${componentName ? `<${componentName}>` : 'this component'}.`
   )
 }

--- a/src/react/react.ts
+++ b/src/react/react.ts
@@ -368,6 +368,9 @@ class RenderOne<P> implements Subscription {
           this._innerSubscription = null
       })
 
+    if (!this._receivedValue && DEV_ENV)
+      warnEmptyObservable(getReactComponentName(this._liftedComponent.props.component))
+
     this._liftedComponent = liftedComponent
     liftedComponent.setState(state)
   }
@@ -378,7 +381,7 @@ class RenderOne<P> implements Subscription {
   }
 
   private _handleValue(value: any) {
-    // only required for empty observable check in _handleCompleted
+    // only required for empty observable check
     this._receivedValue = true
 
     const liftedComponent = this._liftedComponent
@@ -390,9 +393,6 @@ class RenderOne<P> implements Subscription {
   }
 
   private _handleCompleted() {
-    if (!this._receivedValue && DEV_ENV)
-      warnEmptyObservable(getReactComponentName(this._liftedComponent.props.component))
-
     this._innerSubscription = null
     this._liftedComponent.setState(LiftWrapper._endState)
   }

--- a/src/react/react.ts
+++ b/src/react/react.ts
@@ -368,7 +368,7 @@ class RenderOne<P> implements Subscription {
           this._innerSubscription = null
       })
 
-    if (!this._receivedValue && DEV_ENV)
+    if (DEV_ENV && !this._receivedValue)
       warnEmptyObservable(getReactComponentName(this._liftedComponent.props.component))
 
     this._liftedComponent = liftedComponent
@@ -382,7 +382,7 @@ class RenderOne<P> implements Subscription {
 
   private _handleValue(value: any) {
     // only required for empty observable check
-    this._receivedValue = true
+    if (DEV_ENV) this._receivedValue = true
 
     const liftedComponent = this._liftedComponent
     const { component, props } = liftedComponent.props

--- a/test/test_react.tsx
+++ b/test/test_react.tsx
@@ -93,6 +93,14 @@ test('react', t => {
       )
       t.ok(consoleErrorWasCalled, 'console.error() was called')
 
+      consoleErrorWasCalled = false
+      testRender(t,
+        <F.span className={Observable.never()}></F.span>,
+        '',
+        'Render empty element with Observable.never()'
+      )
+      t.ok(consoleErrorWasCalled, 'console.error() was called')
+
       console.error = error
     })()
 

--- a/test/test_react.tsx
+++ b/test/test_react.tsx
@@ -76,10 +76,10 @@ test('react', t => {
         t.ok(consoleErrorWasCalled, 'console.error() called')
         t.is(
           consoleErrorMessage,
-          `[Focal]: The component <span> has received an empty observable ` +
-          `in one of its props. Since such observable never calls its ` +
-          `subscription handler, this component can never be rendered. ` +
-          `Check the props of <span>.`,
+          `[Focal]: The component <span> has received an observable that doesn\'t immediately ` +
+          `emit a value in one of its props. Since this observable hasn\'t yet called its ` +
+          `subscription handler, the component can not be rendered at the time. Check the ` +
+          `props of <span>.`,
           'warning displayed'
         )
 


### PR DESCRIPTION
Originally reported in #25

This PR fixes an inconsistency in how "empty observable warning" is issued between cases with one and many observable props. Since the warning is already issued for non-behavior observables in the `RenderMany` case, this fix only adds it to `RenderOne` case.

We will need to update the wording in the warning message since it will no longer warn only for an empty observable case.

Also I don't consider this to be a breaking change, so I'm not bumping the minor version.

- [x] refactor empty warning tests
- [x] fix empty warning for RenderOne
- [x] improve warning message
- [ ] ~~can we add the offending property name to the warning message?~~ Not this time