### PR TITLE
Source is not properly unsubscribed from in AtomViewImpl

### DIFF
--- a/test/test_atom.ts
+++ b/test/test_atom.ts
@@ -614,4 +614,38 @@ test('atom', t => {
 
     t.end()
   })
+
+  t.test('resubscribe to view', t => {
+    const a = Atom.create(5)
+    const v = a.view(x => x + 1)
+
+    const os: number[] = []
+    const sub1 = v.subscribe(x => {
+      os.push(x)
+    })
+    t.deepEqual(os, [6])
+
+    a.modify(x => x + 1)
+    t.deepEqual(os, [6, 7])
+
+    sub1.unsubscribe()
+
+    a.modify(x => x + 1)
+    t.deepEqual(os, [6, 7])
+
+    const sub2 = v.subscribe(x => {
+      os.push(x)
+    })
+    t.deepEqual(os, [6, 7, 8])
+
+    a.modify(x => x + 1)
+    t.deepEqual(os, [6, 7, 8, 9])
+
+    sub2.unsubscribe()
+
+    a.modify(x => x + 1)
+    t.deepEqual(os, [6, 7, 8, 9])
+
+    t.end()
+  })
 })

--- a/test/test_atom.ts
+++ b/test/test_atom.ts
@@ -648,4 +648,34 @@ test('atom', t => {
 
     t.end()
   })
+
+  t.test('multiple subscriptions to same view', t => {
+    const a = Atom.create(5)
+    const v = a.view(x => x + 1)
+
+    const os1: number[] = []
+    const sub1 = v.subscribe(x => os1.push(x))
+
+    const os2: number[] = []
+    const sub2 = v.subscribe(x => os2.push(x))
+
+    t.deepEqual(os1, [6])
+    t.deepEqual(os2, [6])
+
+    a.set(6)
+    t.deepEqual(os1, [6, 7])
+    t.deepEqual(os2, [6, 7])
+
+    sub1.unsubscribe()
+    a.set(7)
+    t.deepEqual(os1, [6, 7])
+    t.deepEqual(os2, [6, 7, 8])
+
+    sub2.unsubscribe()
+    a.set(8)
+    t.deepEqual(os1, [6, 7])
+    t.deepEqual(os2, [6, 7, 8])
+
+    t.end()
+  })
 })

--- a/test/test_atom.ts
+++ b/test/test_atom.ts
@@ -580,4 +580,38 @@ test('atom', t => {
 
     t.end()
   })
+
+  t.test('unsub in modify', t => {
+    const a = Atom.create(5)
+
+    const viewFnCalls: number[] = []
+    const os: number[] = []
+
+    const v = a.view(x => {
+      viewFnCalls.push(x)
+      return x + 1
+    })
+
+    t.deepEqual(viewFnCalls, [])
+    t.deepEqual(os, [])
+
+    const sub = v.subscribe(x => {
+      os.push(x)
+    })
+    t.deepEqual(viewFnCalls, [5])
+    t.deepEqual(os, [6])
+
+    a.modify(x => x + 1)
+    t.deepEqual(viewFnCalls, [5, 6])
+    t.deepEqual(os, [6, 7])
+
+    a.modify(x => {
+      sub.unsubscribe()
+      return 0
+    })
+    t.deepEqual(viewFnCalls, [5, 6])
+    t.deepEqual(os, [6, 7])
+
+    t.end()
+  })
 })


### PR DESCRIPTION
Reported in #29 

I think it also affects other atom implementations (`CombinedAtomViewImpl`, `LensedAtom`) in the same way. The problem is that the `this._source` observable is not unsubscribed from when `unsubscribe` is called on the subscription returned from `_subscribe`. This causes the view getter function to be called after the view is unsubscribed from.

The repro, which calls `unsubscribe` in a `modify` callback, is not strictly legitimate (you're not supposed to be doing side effects in a `modify` callback), but seems to be a good approximation of what happens in the `reactiveList` use case.