### PR TITLE
Don't import entire RxJS

### DIFF
--- a/examples/todomvc/src/app.tsx
+++ b/examples/todomvc/src/app.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-import { Observable } from 'rxjs'
+import { Observable } from 'rxjs/Observable'
+import 'rxjs/add/observable/defer'
+import 'rxjs/add/observable/fromEvent'
+import 'rxjs/add/operator/map'
+import 'rxjs/add/operator/startWith'
+import 'rxjs/add/operator/combineLatest'
 import { F, Atom, Lens, bind, reactiveList, classes } from '@grammarly/focal'
 import { TodoItem, AppModel } from './model'
 

--- a/src/atom/base.ts
+++ b/src/atom/base.ts
@@ -1,12 +1,10 @@
 import { Lens, Prism, PropExpr } from './../lens'
 import { structEq, Option } from './../utils'
 
-// @TODO importing the whole RxJS here. there is a way to
-// only import operators/types that are used to reduce the
-// resulting bundle size, but I couldn't make it work.
-import {
-  Observable, Subscriber, Subscription, BehaviorSubject
-} from 'rxjs/Rx'
+import { Observable } from 'rxjs/Observable'
+import { Subscriber } from 'rxjs/Subscriber'
+import { Subscription } from 'rxjs/Subscription'
+import { BehaviorSubject } from 'rxjs/BehaviorSubject'
 
 /**
  * Read-only atom.

--- a/src/react/observablePropTypes.ts
+++ b/src/react/observablePropTypes.ts
@@ -18,7 +18,7 @@
  * @module
  */
 import * as React from 'react'
-import { Observable } from 'rxjs'
+import { Observable } from 'rxjs/Observable'
 
 export type ObservableOr<T> = Observable<T> | T
 export type AcceptObservableValues<T> = { [K in keyof T]: ObservableOr<T[K]> }

--- a/src/react/react.ts
+++ b/src/react/react.ts
@@ -7,6 +7,7 @@ import { Observable, ObservableInput } from 'rxjs/Observable'
 import { Subscription as RxSubscription } from 'rxjs/Subscription'
 import 'rxjs/add/operator/scan'
 import 'rxjs/add/operator/map'
+import 'rxjs/add/observable/of'
 import 'rxjs/add/observable/combineLatest'
 
 export interface Subscription {

--- a/src/react/react.ts
+++ b/src/react/react.ts
@@ -13,7 +13,7 @@ import 'rxjs/add/observable/combineLatest'
 // Atom namespace in atom/index.ts
 //
 // if we don't do it, we get the "cannot be named" compiler error.
-import { Atom as _Atom } from './../atom/base' // tslint:disable-line no-unused-vars
+// import { Atom as _Atom } from './../atom/base' // tslint:disable-line no-unused-vars
 
 export interface Subscription {
   unsubscribe(): void

--- a/src/react/react.ts
+++ b/src/react/react.ts
@@ -9,12 +9,6 @@ import 'rxjs/add/operator/scan'
 import 'rxjs/add/operator/map'
 import 'rxjs/add/observable/combineLatest'
 
-// a hack required to support the declaration merging of the Atom type and
-// Atom namespace in atom/index.ts
-//
-// if we don't do it, we get the "cannot be named" compiler error.
-// import { Atom as _Atom } from './../atom/base' // tslint:disable-line no-unused-vars
-
 export interface Subscription {
   unsubscribe(): void
 }

--- a/test/manual/package.json
+++ b/test/manual/package.json
@@ -15,8 +15,8 @@
   "author": "Grammarly, Inc.",
   "license": "(c) 2016 Grammarly",
   "devDependencies": {
-    "@grammarly/focal": "0.6.436",
     "@grammarly/tslint-config": "^0.3.1",
+    "@types/node": "^9.6.0",
     "@types/react": "16.0.33",
     "@types/react-dom": "16.0.3",
     "express": "^4.14.0",

--- a/test/manual/package.json
+++ b/test/manual/package.json
@@ -32,6 +32,7 @@
     "tslint-loader": "^3.3.0",
     "typescript": "2.4.1",
     "webpack": "^1.13.2",
+    "webpack-bundle-analyzer": "^2.11.1",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-fail-plugin": "2.0.0",
     "webpack-hot-middleware": "^2.12.2"

--- a/test/manual/src/render-bug/index.tsx
+++ b/test/manual/src/render-bug/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { F, Atom } from '@grammarly/focal'
-import { Observable } from 'rxjs'
+import { Observable } from 'rxjs/Observable'
+import 'rxjs/add/observable/of'
 
 let globalCounter = 0
 
@@ -55,7 +56,6 @@ const MinimalReproduce = () => {
         const ts = mkName()
         return <El key={i} text={text.toString()} ts={ts} />
       }))}
-
   </F.div>
 }
 

--- a/test/manual/tsconfig.json
+++ b/test/manual/tsconfig.json
@@ -7,7 +7,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "outDir": "build",
-    "rootDir": ".",
     "noEmitOnError": true,
     "noImplicitReturns": true,
     "noImplicitAny": true,
@@ -15,7 +14,10 @@
     "moduleResolution": "node",
     "strictNullChecks": true,
     "lib": ["es6", "es2015", "dom", "scripthost"],
-    "types": []
+    "baseUrl": ".",
+    "paths": {
+      "@grammarly/focal": ["../../dist/src"]
+    }
   },
   "include": [
     "src/**/*.ts*"

--- a/test/manual/webpack/webpack.dev.js
+++ b/test/manual/webpack/webpack.dev.js
@@ -16,13 +16,11 @@ module.exports = {
   module: {
     preLoaders: [{
       test: /\.tsx?$/,
-      loader: 'tslint',
-      include: APP_DIR
+      loader: 'tslint'
     }],
     loaders: [{
       test: /\.tsx?$/,
-      loaders: ['ts'],
-      include: APP_DIR
+      loaders: ['ts']
     }]
   },
   output: {
@@ -37,6 +35,10 @@ module.exports = {
   ],
   resolve: {
     root: [path.resolve('../src')],
+    alias: {
+      '@grammarly/focal': path.join(APP_DIR, '..', '..', '..', 'dist', 'src'),
+      'rxjs': path.join(APP_DIR, '..', 'node_modules', 'rxjs')
+    },
     extensions: ['', '.tsx', '.ts', '.jsx', '.js']
   }
 };

--- a/test/manual/webpack/webpack.dev.js
+++ b/test/manual/webpack/webpack.dev.js
@@ -34,10 +34,9 @@ module.exports = {
     failPlugin
   ],
   resolve: {
-    root: [path.resolve('../src')],
+    root: [path.resolve('../src'), path.join(APP_DIR, '..', 'node_modules')],
     alias: {
-      '@grammarly/focal': path.join(APP_DIR, '..', '..', '..', 'dist', 'src'),
-      'rxjs': path.join(APP_DIR, '..', 'node_modules', 'rxjs')
+      '@grammarly/focal': path.join(APP_DIR, '..', '..', '..', 'dist', 'src')
     },
     extensions: ['', '.tsx', '.ts', '.jsx', '.js']
   }

--- a/test/manual/webpack/webpack.prod.js
+++ b/test/manual/webpack/webpack.prod.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var webpack = require('webpack');
+var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 
 var APP_DIR = path.join(__dirname, '..', 'src');
 
@@ -9,13 +10,11 @@ module.exports = {
   module: {
     preLoaders: [{
       test: /\.tsx?$/,
-      loader: 'tslint',
-      include: APP_DIR
+      loader: 'tslint'
     }],
     loaders: [{
       test: /\.tsx?$/,
-      loaders: ['ts'],
-      include: APP_DIR
+      loaders: ['ts']
     }]
   },
   output: {
@@ -34,10 +33,19 @@ module.exports = {
       compressor: {
         warnings: false
       }
+    }),
+    new BundleAnalyzerPlugin({
+      analyzerMode: 'static',
+      openAnalyzer: false,
+      defaultSizes: 'parsed',
+      generateStatsFile: true
     })
   ],
   resolve: {
-    root: [path.resolve('../src')],
+    root: [path.resolve('../src'), path.join(APP_DIR, '..', 'node_modules')],
+    alias: {
+      '@grammarly/focal': path.join(APP_DIR, '..', '..', '..', 'dist', 'src')
+    },
     extensions: ['', '.tsx', '.ts', '.jsx', '.js']
   },
   tslint: {

--- a/test/test_atom.ts
+++ b/test/test_atom.ts
@@ -1,5 +1,6 @@
 // tslint:disable no-unnecessary-local-variable
 import * as test from 'tape'
+import 'rxjs/add/operator/merge'
 import { Atom, Lens } from '../src'
 import { structEq } from '../src/utils'
 

--- a/test/test_react.tsx
+++ b/test/test_react.tsx
@@ -1,6 +1,8 @@
 import * as test from 'tape'
 import { Observable } from 'rxjs/Observable'
 import 'rxjs/add/observable/of'
+import 'rxjs/add/observable/empty'
+import 'rxjs/add/observable/never'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom/server'
 


### PR DESCRIPTION
Not importing entire RxJS anymore, only stuff that's used. Confirmed with bundle analyzer.

Before:
![image](https://user-images.githubusercontent.com/1118870/37853855-aee0bec6-2ea5-11e8-8e25-9b2945e387a4.png)

After:
![image](https://user-images.githubusercontent.com/1118870/37812879-9c9f5366-2e1f-11e8-85bf-8d815430a8d1.png)
