### PR TITLE
Fix component mount prop type

### DIFF
--- a/src/react/intrinsic.ts
+++ b/src/react/intrinsic.ts
@@ -8,7 +8,7 @@ import { ObservableReactHTMLProps } from './observablePropTypes'
 import { LiftWrapperProps, LiftWrapper } from './react'
 
 export interface LiftedIntrinsicComponentProps<E> extends ObservableReactHTMLProps<E> {
-  mount?(el: E): void
+  mount?: React.Ref<E>
 }
 
 export interface LiftedIntrinsic<E extends Element> {

--- a/src/react/react.ts
+++ b/src/react/react.ts
@@ -116,7 +116,7 @@ export class LiftWrapper<TProps>
 // will also accept a value of Observable<T> for any prop of
 // type T.
 export type LiftedComponentProps<TProps> = Lifted<TProps> & {
-  mount?(el: HTMLElement): void
+  mount?: React.Ref<HTMLElement>
 }
 
 /**
@@ -214,6 +214,7 @@ function render<P>(
   props: P,
   observedValues: any[] = []
 ): React.DOMElement<any, any> {
+  // @TODO can we do a better type here?
   const newProps: any = {}
   let newChildren: any
   let k = -1


### PR DESCRIPTION
Currently the type of the `mount` prop incorrectly says that the parameter of the supplied function is a non-null value. At runtime, it is going to be the same argument as passed down to `ref`'s callback from React, so its type is the same. The precise type is described in React typings as this:

```
type Ref<T> = string | { bivarianceHack(instance: T | null): any }["bivarianceHack"];
```

Not sure about the `bivarianceHack` thing, I'll just refer to this exact type in Focal.