### PR TITLE
Fix return type of bindElementProps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 jobs:
   include:
     - stage: github release
-      script: yarn build && yarn package
+      script: yarn build && yarn test && yarn package
       deploy:
         provider: releases
         api_key:

--- a/packages/examples/all/package.json
+++ b/packages/examples/all/package.json
@@ -19,7 +19,7 @@
   "author": "Grammarly, Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grammarly/focal": "*",
+    "@grammarly/focal": "0.8.0-alpha.0",
     "@grammarly/tslint-config": "0.5.1",
     "@types/react": "16.0.33",
     "@types/react-dom": "16.0.3",

--- a/packages/examples/todomvc/package.json
+++ b/packages/examples/todomvc/package.json
@@ -19,7 +19,7 @@
   "author": "Grammarly, Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grammarly/focal": "*",
+    "@grammarly/focal": "0.8.0-alpha.0",
     "@grammarly/tslint-config": "0.5.1",
     "@types/react": "16.0.33",
     "@types/react-dom": "16.0.3",

--- a/packages/focal/src/react/react.ts
+++ b/packages/focal/src/react/react.ts
@@ -680,12 +680,23 @@ export function getElementProps(template: { [key: string]: Atom<any> }) {
   }
 }
 
+type BindElementPropsReturnType =
+  | {
+      [x: string]: ((e: React.SyntheticEvent<any>) => void) | ((domElement: Element | null) => void)
+      [PROP_REF](domElement: Element | null): void
+    }
+  | {
+      [x: string]: ((e: React.SyntheticEvent<any>) => void) | ((domElement: Element | null) => void)
+      [PROP_MOUNT](domElement: Element | null): void
+    }
+  | {}
+
 export function bindElementProps(
   // @TODO need to fix the type of { [k: string]: string | Atom<any> }.
   // this function already compiles without the 'string | ...', but it's
   // calls do not.
   template: { ref?: string; mount?: string } & { [k: string]: string | Atom<any> }
-) {
+): BindElementPropsReturnType {
   const { [PROP_REF]: ref, [PROP_MOUNT]: mount, ...tpl } = template
 
   return ref

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -15,7 +15,7 @@
   "author": "Grammarly, Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grammarly/focal": "*",
+    "@grammarly/focal": "0.8.0-alpha.0",
     "@grammarly/tslint-config": "0.5.1",
     "@types/node": "^9.6.0",
     "@types/react": "16.0.33",


### PR DESCRIPTION
Fixes #43

Due to a complex return type of `bindElementProps`, TS was unable to infer a valid signature in react.d.ts.
This PR fixes the issue in a quick way.