### PR TITLE
Fix webpack tree shacking (add lens json side effect)

### DIFF
--- a/packages/focal/package.json
+++ b/packages/focal/package.json
@@ -6,7 +6,11 @@
   "module": "dist/_esm5/src/index.js",
   "es2015": "dist/_esm2015/src/index.js",
   "types": "dist/_cjs/src/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/_cjs/src/lens/json.js",
+    "./dist/_esm5/src/lens/json.js",
+    "./dist/_esm2015/src/lens/json.js"
+  ],
   "files": [
     "dist/_cjs/src/",
     "dist/_esm5/src/",


### PR DESCRIPTION
Webpack production mode ignores unused import. So we don't add needed methods to `Lens` object. To fix it we need to add a `sideEffect` on importing of `json` module.