### PR TITLE
Fix tree-shaking

### DIFF
--- a/packages/focal/package.json
+++ b/packages/focal/package.json
@@ -7,6 +7,9 @@
   "es2015": "dist/_esm2015/src/index.js",
   "types": "dist/_cjs/src/index.d.ts",
   "sideEffects": [
+    "./dist/_cjs/src/lens/index.js",
+    "./dist/_esm5/src/lens/index.js",
+    "./dist/_esm2015/src/lens/index.js",
     "./dist/_cjs/src/lens/json.js",
     "./dist/_esm5/src/lens/json.js",
     "./dist/_esm2015/src/lens/json.js"


### PR DESCRIPTION
After migrating to the Focal version 0.8.1, I have got the same error as in issue #66. It turned out that the reason was that the effectful module `lens/json.js` did not make it to the production bundle because `sideEffects` were set to `false` in `package.json`. However, the `sideEffects` update in the MR #65 did not fix the problem, and the module was still not included in the bundle. I have found that we also need to add the `lens/index.js` module to the `sideEffects` for `lens/json.js` module to appear in the production build. 

After adding this module to the `sideEffects` field, the `lens/json` module is added to the bundle and the `.key is not a function` error does not happen anymore.