### PR TITLE
custom equals when creating an atom

### DIFF
--- a/packages/focal/src/atom/base.ts
+++ b/packages/focal/src/atom/base.ts
@@ -297,7 +297,7 @@ export abstract class AbstractAtom<T>
 }
 
 export class JsonAtom<T> extends AbstractAtom<T> {
-  constructor(initialValue: T) {
+  constructor(initialValue: T, private _eq: (x: T, y: T) => boolean = structEq) {
     super(initialValue)
   }
 
@@ -309,14 +309,14 @@ export class JsonAtom<T> extends AbstractAtom<T> {
     const prevValue = this.getValue()
     const next = updateFn(prevValue)
 
-    if (!structEq(prevValue, next))
+    if (!this._eq(prevValue, next))
       this.next(next)
   }
 
   set(x: T) {
     const prevValue = this.getValue()
 
-    if (!structEq(prevValue, x))
+    if (!this._eq(prevValue, x))
       this.next(x)
   }
 }

--- a/packages/focal/src/atom/index.ts
+++ b/packages/focal/src/atom/index.ts
@@ -23,10 +23,24 @@ export namespace Atom {
    * @export
    * @template T type of atom values
    * @param initialValue initial value for this atom
+   * @param eq - optional custom equality check function,
+   * used to compare prev and next atom values to emit value only when it has changed.
+   *
+   * !!!BEWARE!!!: make sure that your custom equality check function is optimal
+   * (e.g. checks for value reference equality first),
+   * as it will be called EVERY time an atom value is changed
+   *
+   * (when setting(modifying) an atom value, a new value is only emitted by atom if it has changed,
+   * i.e. it does not equal to the previous value)
+   *
+   * If not specified, a default private implementation of structure equality is used.
+   *
+   * As an alternative, a value may have an 'equals' method that will be recognized
+   * by default structure equality implementation
    * @returns fresh atom
    */
-  export function create<T>(initialValue: T): Atom<T> {
-    return new JsonAtom(initialValue)
+  export function create<T>(initialValue: T, eq?: (x: T, y: T) => boolean): Atom<T> {
+    return new JsonAtom(initialValue, eq)
   }
 
   // tslint:disable no-unused-vars


### PR DESCRIPTION
This will allow `Atom.create` clients to provide a custom implementation of equality check explicitly, instead of having an `equals` method on the value. 

This can be useful when we want to have the atom's value as a serializable POJO that could not have any function members.