### PR TITLE
Change compiler target for the ES2015 build from esnext to ES2015

### DIFF
--- a/packages/focal/package.json
+++ b/packages/focal/package.json
@@ -24,7 +24,7 @@
     "clean": "rm -rf ./dist",
     "build:cjs": "tsc --module commonjs --target es5 --outDir dist/_cjs",
     "build:es5": "tsc --module es2015 --outDir dist/_esm5",
-    "build:es2015": "tsc --module es2015 --target esnext --outDir dist/_esm2015",
+    "build:es2015": "tsc --module es2015 --target es2015 --outDir dist/_esm2015",
     "build": "npm run clean && yarn build:cjs && yarn build:es5 && yarn build:es2015 && npm run lint",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
As it turned out, current Focal's ES6-build is not ES6-compliant and is not supported in some older browsers (e.g. Legacy MS Edge). This happens because of the build script misconfiguration – the build target provided to the `tsc` is `esnext`. Because of that, some of the more recent language features (e.g. Object literal spread operator) appear in the ES6 build. This MR changes the build target to the expected one for the ES6 build.