### PR TITLE
Improve release

### DIFF
--- a/.github/workflows/Readme.md
+++ b/.github/workflows/Readme.md
@@ -2,7 +2,11 @@
 
 ## Release
 
-For each tag `v*` that is pushed into `master` branch CI creates ["Release"](https://github.com/grammarly/focal/releases) and attaches package tarball `grammarly-focal-v*.tgz`. For details see `release.yml`
+1. Create pull-request for relese "Release vX.X.X"
+2. Run in root `yarn bump-release X.X.X`
+3. yarn bump-release will bump focal version, update deps in private packages and create a commit
+4. Merge and manually create [GitHub Release](https://github.com/grammarly/focal/releases)
+5. On release "publish" GitHub Actions will trigger build and attach tarball to "Release". For details see `release.yml`
 
 ## Tests
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,18 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  release:
+    types: [published]
 
 jobs:
   release:
-    # There is no way to run a workflow on push tags on a specific branch.
-    # The job should be skipped when running for a non-master branch.
-    if: github.ref == 'refs/heads/master'
-    name: Release (skip on non-main branch)
+    name: Release
     runs-on: ubuntu-latest
     steps:
       - name: Branch name
         id: branch_name
         run: |
+          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
           echo ::set-output name=TARBALL::grammarly-focal-${GITHUB_REF#refs/tags/}.tgz
       - name: Checkout code
         uses: actions/checkout@v2
@@ -23,23 +20,10 @@ jobs:
       - run: yarn build
       - run: yarn test
       - run: yarn package
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./packages/focal/${{ steps.branch_name.outputs.TARBALL }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./packages/focal/${{ steps.branch_name.outputs.TARBALL }}
           asset_name: ${{ steps.branch_name.outputs.TARBALL }}
-          asset_content_type: application/zip
+          tag: ${{ github.ref }}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "build": "yarn workspace @grammarly/focal build",
     "package": "yarn workspace @grammarly/focal pack",
     "test": "yarn workspace @grammarly/focal test && yarn workspace focal-todomvc build && yarn workspace focal-examples build && yarn workspace focal-manual-tests build",
-    "postinstall": "yarn build"
+    "postinstall": "yarn build",
+    "bump-version": "sh ./scripts/release.sh"
   },
   "devDependencies": {
     "@grammarly/tslint-config": "0.5.1",

--- a/packages/examples/all/package.json
+++ b/packages/examples/all/package.json
@@ -20,7 +20,7 @@
   "author": "Grammarly, Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grammarly/focal": "0.8.4",
+    "@grammarly/focal": "0.8.5",
     "@grammarly/tslint-config": "0.5.1",
     "@types/react": "16.9.11",
     "@types/react-dom": "16.9.3",

--- a/packages/examples/todomvc/package.json
+++ b/packages/examples/todomvc/package.json
@@ -20,7 +20,7 @@
   "author": "Grammarly, Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grammarly/focal": "0.8.4",
+    "@grammarly/focal": "0.8.5",
     "@grammarly/tslint-config": "0.5.1",
     "@types/react": "16.9.11",
     "@types/react-dom": "16.9.3",

--- a/packages/focal/package.json
+++ b/packages/focal/package.json
@@ -28,7 +28,7 @@
     "build": "npm run clean && yarn build:cjs && yarn build:es5 && yarn build:es2015 && npm run lint",
     "test": "jest",
     "test:watch": "jest --watch",
-    "lint": "eslint './src/**/*.ts*' './test/**/*.ts*' && tsc --noemit",
+    "lint": "tslint --type-check --project tsconfig.json -c tslint.json",
     "prepack": "cp ../../README.md ./ && cp ../../LICENSE ./",
     "postpack": "rm README.md && rm LICENSE"
   },

--- a/packages/focal/package.json
+++ b/packages/focal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grammarly/focal",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "FRP UI with React, observables, immutable data and lenses",
   "main": "dist/_cjs/src/index.js",
   "module": "dist/_esm5/src/index.js",

--- a/packages/focal/package.json
+++ b/packages/focal/package.json
@@ -30,8 +30,7 @@
     "test:watch": "jest --watch",
     "lint": "eslint './src/**/*.ts*' './test/**/*.ts*' && tsc --noemit",
     "prepack": "cp ../../README.md ./ && cp ../../LICENSE ./",
-    "postpack": "rm README.md && rm LICENSE",
-    "preversion": "if ! [[ $(git rev-parse --abbrev-ref HEAD) == \"master\" ]]; then echo \"Not on the master branch.\" && exit 1; fi"
+    "postpack": "rm README.md && rm LICENSE"
   },
   "author": "Sergey Yavnyi <sergey.yavnyi@grammarly.com>",
   "contributors": [

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -16,7 +16,7 @@
   "author": "Grammarly, Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grammarly/focal": "0.8.4",
+    "@grammarly/focal": "0.8.5",
     "@grammarly/tslint-config": "0.5.1",
     "@types/node": "^9.6.0",
     "@types/react": "16.9.11",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+VER=$1
+
+echo "Releasing version $1"
+
+cd packages/focal && yarn version --new-version $VER --no-git-tag-version && cd ../..
+sed -i '' 's/grammarly\/focal":.*$/grammarly\/focal": "'${VER}'",/g' packages/examples/all/package.json
+sed -i '' 's/grammarly\/focal":.*$/grammarly\/focal": "'${VER}'",/g' packages/examples/todomvc/package.json
+sed -i '' 's/grammarly\/focal":.*$/grammarly\/focal": "'${VER}'",/g' packages/test/package.json
+# yarn
+git add .
+git commit -m "v$VER"


### PR DESCRIPTION
### Introduce manual release. 

The maintainer should manually create a GitHub release to trigger a build that attaches tarball to the release.

<img width="961" alt="Screenshot 2021-02-03 at 14 08 53" src="https://user-images.githubusercontent.com/576013/106745168-63dc3400-6629-11eb-8265-006fc4a38466.png">


### Script to bump version

Use `yarn bump-version X.X.X` to bump focal version and update deps in private packages.
