### PR TITLE
Simplify check for promises in equals

### DIFF
--- a/packages/focal-atom/src/equals.ts
+++ b/packages/focal-atom/src/equals.ts
@@ -35,10 +35,9 @@ function arrayFromIterator<T>(iter: Iterator<T>) {
   return result
 }
 
-function functionName(f: Function) {
-  // String(x => x) evaluates to "x => x", so the pattern may not match.
-  const match = String(f).match(/^function (\w*)/)
-  return match == null ? '' : match[1]
+function isPromise(a: unknown) {
+  // The function checks that is a 'thenable'
+  return Boolean(value && typeof (value as Promise<unknown>).then === 'function')
 }
 
 function has(prop: string, obj: any) {
@@ -207,8 +206,7 @@ export function structEq(a: any, b: any, stackA: any[] = [], stackB: any[] = [])
     case 'Arguments':
     case 'Array':
     case 'Object':
-      if (typeof a.constructor === 'function' &&
-        functionName(a.constructor) === 'Promise') {
+      if (isPromise(a)) {
         return a === b
       }
       break

--- a/packages/focal-atom/src/equals.ts
+++ b/packages/focal-atom/src/equals.ts
@@ -35,9 +35,9 @@ function arrayFromIterator<T>(iter: Iterator<T>) {
   return result
 }
 
-function isPromise(value: unknown) {
+function isPromise(value: unknown): value is PromiseLike<unknown> {
   // The function checks that is a 'thenable'
-  return Boolean(value && typeof (value as Promise<unknown>).then === 'function')
+  return value !== null && value !== undefined && typeof (value as PromiseLike<unknown>).then === 'function'
 }
 
 function has(prop: string, obj: any) {

--- a/packages/focal-atom/src/equals.ts
+++ b/packages/focal-atom/src/equals.ts
@@ -35,7 +35,7 @@ function arrayFromIterator<T>(iter: Iterator<T>) {
   return result
 }
 
-function isPromise(a: unknown) {
+function isPromise(value: unknown) {
   // The function checks that is a 'thenable'
   return Boolean(value && typeof (value as Promise<unknown>).then === 'function')
 }

--- a/packages/focal-atom/test/equals.test.ts
+++ b/packages/focal-atom/test/equals.test.ts
@@ -1,0 +1,23 @@
+import { structEq } from '../src/equals'
+
+describe('structEq', () => {
+  describe('promises', () => {
+    it('matches exact same promises', () => {
+      const p1 = Promise.resolve(1)
+      const p2 = Promise.resolve(1)
+
+      expect(structEq(p1, p1)).toEqual(true)
+      expect(structEq(p2, p2)).toEqual(true)
+      expect(structEq(p1, p2)).toEqual(false)
+    })
+
+    it('matches exact same thenables', () => {
+      const p1 = { then() {} }
+      const p2 = { then() {} }
+
+      expect(structEq(p1, p1)).toEqual(true)
+      expect(structEq(p2, p2)).toEqual(true)
+      expect(structEq(p1, p2)).toEqual(false)
+    })
+  })
+})


### PR DESCRIPTION
The current implementation of the `equals` function performs a check if the given object is a Promise by pattern-matching stringified function.

Since the function might redefine its `toString` function, the check is not considered a reliable.

According to Promises A+ spec, the only way to check if the object is *thenable* is that it has a member called `then` that is a function.
