### PR TITLE
Declare no side effects in the modules

### DIFF
--- a/.changeset/itchy-monkeys-matter.md
+++ b/.changeset/itchy-monkeys-matter.md
@@ -1,0 +1,6 @@
+---
+"@grammarly/focal": minor
+"@grammarly/focal-atom": minor
+---
+
+Mark packages as side-effect free for proper tree shaking by Webpack and other bundlers.

--- a/packages/focal-atom/package.json
+++ b/packages/focal-atom/package.json
@@ -9,6 +9,7 @@
     "dist/_cjs/src/",
     "dist/_esm2015/src/"
   ],
+  "sideEffects": false,
   "scripts": {
     "docs": "rm -rf ./docs && typedoc --out docs --theme minimal --ignoreCompilerErrors --tsconfig tsconfig.json",
     "clean": "rm -rf ./dist",

--- a/packages/focal/package.json
+++ b/packages/focal/package.json
@@ -9,6 +9,7 @@
     "dist/_cjs/src/",
     "dist/_esm2015/src/"
   ],
+  "sideEffects": false,
   "scripts": {
     "docs": "rm -rf ./docs && typedoc --out docs --theme minimal --ignoreCompilerErrors --tsconfig tsconfig.json",
     "clean": "rm -rf ./dist",


### PR DESCRIPTION
After recent modification ES modules are correctly loaded but tree-shaking in Webpack also requires declaring the packages to be side effects-free. This is done by declaring `sideEffects: false` in the package manifests.