### PR TITLE
Enable creating GitHub releases in version.yml workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -24,3 +24,4 @@ jobs:
           publish: yarn changeset tag
           commit: Version packages
           title: Release packages
+          createGithubReleases: true


### PR DESCRIPTION
Current `@changesets/action` integration doesn't seem to create GutHub releases (although docs says it is on by default). looking at their code doesn't indicate it is default.

So adding the parameter.
